### PR TITLE
update READMEs with more Intel compiler flags

### DIFF
--- a/csgf-hpc-day/IntroToCori/ex5-vtune/README.md
+++ b/csgf-hpc-day/IntroToCori/ex5-vtune/README.md
@@ -51,7 +51,10 @@ $ cp ../../hack-a-kernel/hack-a-kernel.f90 .
 ```
 
 ```console
-$ ftn -g -debug inline-debug-info -O2 -dynamic -parallel-source-info=2 -o hack-a-kernel-vtune.ex hack-a-kernel.f90
+$ ftn -g -debug inline-debug-info -O2 \
+      -dynamic -parallel-source-info=2 \
+      -qopt-report-phase=vec \
+      -o hack-a-kernel-vtune.ex hack-a-kernel.f90
 ```
 
 ### Step 3: Run the application

--- a/csgf-hpc-day/IntroToCori/ex5-vtune/README.md
+++ b/csgf-hpc-day/IntroToCori/ex5-vtune/README.md
@@ -51,9 +51,9 @@ $ cp ../../hack-a-kernel/hack-a-kernel.f90 .
 ```
 
 ```console
-$ ftn -g -debug inline-debug-info -O2 \
+$ ftn -g -debug inline-debug-info -O2 -qopenmp \
       -dynamic -parallel-source-info=2 \
-      -qopt-report-phase=vec \
+      -qopt-report-phase=vec,openmp \
       -o hack-a-kernel-vtune.ex hack-a-kernel.f90
 ```
 

--- a/csgf-hpc-day/hack-a-kernel/README-rules.md
+++ b/csgf-hpc-day/hack-a-kernel/README-rules.md
@@ -6,9 +6,9 @@ We recommend working in teams of 2-3 people
 
 ```console
 $ module swap craype-haswell craype-mic-knl
-$ ftn -g -debug inline-debug-info -O2 \
+$ ftn -g -debug inline-debug-info -O2 -qopenmp \
       -dynamic -parallel-source-info=2 \
-      -qopt-report-phase=vec \
+      -qopt-report-phase=vec,openmp \
       -o hack-a-kernel-vtune.ex hack-a-kernel.f90
 ```
 

--- a/csgf-hpc-day/hack-a-kernel/README-rules.md
+++ b/csgf-hpc-day/hack-a-kernel/README-rules.md
@@ -6,7 +6,10 @@ We recommend working in teams of 2-3 people
 
 ```console
 $ module swap craype-haswell craype-mic-knl
-$ ftn hack-a-kernel.f90 -o hack-a-kernel.ex
+$ ftn -g -debug inline-debug-info -O2 \
+      -dynamic -parallel-source-info=2 \
+      -qopt-report-phase=vec \
+      -o hack-a-kernel-vtune.ex hack-a-kernel.f90
 ```
 
 ## Run:


### PR DESCRIPTION
In particular, we add `-qopt-report-phase` which will generate a .optrpt file for each source file with information about which loops were parallelized via OpenMP and/or SIMD.